### PR TITLE
Fix hanging caused by pool exhaustion from improperly handling connection errors

### DIFF
--- a/kiddiepool.py
+++ b/kiddiepool.py
@@ -217,7 +217,7 @@ class KiddiePool(object):
         seconds.
         """
         try:
-            conn = self.connection_pool.get(self.pool_timeout)
+            conn = self.connection_pool.get(timeout=self.pool_timeout)
         except queue.Empty:
             raise KiddiePoolEmpty(
                     'All %d connections checked out' % self.max_size)


### PR DESCRIPTION
Used socketconsole to get a stack trace where it was blocking:

``` python
  File "/home/schmichael/src/ua/XXX/lib/python2.6/site-packages/pykafkap-0.1.0-py2.6.egg/kafkap.py", line 65, in send
    return self.sendmulti([message], topic, partition)
  File "/home/schmichael/src/ua/XXX/lib/python2.6/site-packages/pykafkap-0.1.0-py2.6.egg/kafkap.py", line 70, in sendmulti
    return self._sendall(payload)
  File "/home/schmichael/src/ua/kiddiepool/kiddiepool.py", line 272, in _sendall
    with self.pool.connection() as conn:
  File "/usr/lib/python2.6/contextlib.py", line 16, in __enter__
    return self.gen.next()
  File "/home/schmichael/src/ua/kiddiepool/kiddiepool.py", line 226, in connection
    conn = self.get()
  File "/home/schmichael/src/ua/kiddiepool/kiddiepool.py", line 203, in get
    conn = self.connection_pool.get(self.pool_timeout)
  File "/usr/lib/python2.6/Queue.py", line 168, in get
    self.not_empty.wait()
  File "/usr/lib/python2.6/threading.py", line 239, in wait
    waiter.acquire()
```
