### PR TITLE
Pass full exception data to handle_exception and use issubclass

### DIFF
--- a/kiddiepool.py
+++ b/kiddiepool.py
@@ -59,7 +59,8 @@ class _ConnectionContext(object):
         self.pool.put(self.conn)
         if exc_type is not None:
             # Let handle_exception suppress the exception if desired
-            return bool(self.conn.handle_exception(exc_value))
+            return bool(
+                    self.conn.handle_exception(exc_type, exc_value, exc_tb))
 
 
 class KiddieConnection(object):
@@ -144,9 +145,9 @@ class KiddieConnection(object):
             received += len(chunk)
         return b"".join(data)
 
-    def handle_exception(self, e):
+    def handle_exception(self, exc_type, exc_value, exc_tb):
         """Close connection on socket errors"""
-        if isinstance(e, socket.error):
+        if issubclass(exc_type, socket.error):
             self.close()
 
     def validate(self):
@@ -335,8 +336,8 @@ class FakeConnection(object):
     def recvall(self, size):
         return ''
 
-    def handle_exception(self, e):
-        if isinstance(e, socket.error):
+    def handle_exception(self, et, ev, etb):
+        if issubclass(et, socket.error):
             self.close()
 
     def validate(self):


### PR DESCRIPTION
The `__exit__` method on context managers in Python 2.6 receives `socket.error` instances (`exc_value` in this code) as tuples (Python 2.7 receives actual `socket.error` instances) which breaks the default `handle_exception` implementation.

The default `handle_exception` implementation used `isinstance(exc_value, socket.error)` to determine is `exc_value` was a `socket.error`, and if so: invalidate (close) the socket. This is critical to reconnect logic because if the socket isn't invalidated it will be reused.

This should fix `handle_exception` and therefore validation/retry logic for Python 2.6.
